### PR TITLE
ignoring styles and netlify configuration files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ node_modules
 /build
 /dist
 storybook-static
+src/lib/styles.css
+
+# utility
+netlify.toml
 
 # OS
 .DS_Store


### PR DESCRIPTION
adding tailwind compiled styles and netlify.toml to the gitignore.

- `src/lib/styles.css`  is recreated every time tailwind is compiled.
- `netlify.toml` is specifies the build command.  The docs and main branches go to two different deployements.  The main branch builds teh example output. The docs branch builds the storybook output.  

Note that neither of these netlify deployments use the build command. This is correct. The normal build command is used during the publish step. 